### PR TITLE
Validate select (multiple choice) values.

### DIFF
--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -97,7 +97,7 @@ class InvalidDate(CaseRowError):
 
 
 class InvalidSelectValue(CaseRowError):
-    title = ugettext_noop('Unexpected muliple choice value')
+    title = ugettext_noop('Unexpected multiple choice value')
     message = ugettext_lazy(
         "Multiple choice values were specified that are not listed "
         "in the valid values defined in the property's data dictionary."

--- a/corehq/apps/case_importer/exceptions.py
+++ b/corehq/apps/case_importer/exceptions.py
@@ -96,6 +96,14 @@ class InvalidDate(CaseRowError):
     )
 
 
+class InvalidSelectValue(CaseRowError):
+    title = ugettext_noop('Unexpected muliple choice value')
+    message = ugettext_lazy(
+        "Multiple choice values were specified that are not listed "
+        "in the valid values defined in the property's data dictionary."
+    )
+
+
 class BlankExternalId(CaseRowError):
     title = ugettext_noop('Blank External ID')
     message = ugettext_lazy(

--- a/corehq/apps/case_importer/tests/test_importer.py
+++ b/corehq/apps/case_importer/tests/test_importer.py
@@ -578,6 +578,35 @@ class ImporterTest(TestCase):
         self.assertEqual(0, res['failed_count'])
         self.assertFalse(res['errors'])
 
+    def test_select_validity_checking(self):
+        setup_data_dictionary(self.domain, self.default_case_type,
+                              [('mc', 'select'), ('d1', 'date')], {'mc': ['True', 'False']})
+        file_rows = [
+            ['case_id', 'd1', 'mc'],
+            ['', '2022-04-01', 'True'],
+            ['', '1965-03-30', 'false'],
+            ['', '1944-06-15', ''],
+        ]
+
+        # With validity checking enabled, the bad choice on row 3
+        # should case that row to fail to import and should be
+        # flagged as invalid. The blank one should be valid.
+        with flag_enabled('CASE_IMPORT_DATA_DICTIONARY_VALIDATION'):
+            res = self.import_mock_file(file_rows)
+        self.assertEqual(2, res['created_count'])
+        self.assertEqual(0, res['match_count'])
+        self.assertEqual(1, res['failed_count'])
+        self.assertTrue(res['errors'])
+        error_message = exceptions.InvalidSelectValue.title
+        self.assertEqual(res['errors'][error_message]['mc']['rows'], [3])
+
+        # Without the flag enabled, all the rows should be imported.
+        res = self.import_mock_file(file_rows)
+        self.assertEqual(3, res['created_count'])
+        self.assertEqual(0, res['match_count'])
+        self.assertEqual(0, res['failed_count'])
+        self.assertFalse(res['errors'])
+
     def test_columns_and_rows_align(self):
         with get_commcare_user(self.domain) as case_owner:
             res = self.import_mock_file([

--- a/corehq/apps/data_dictionary/models.py
+++ b/corehq/apps/data_dictionary/models.py
@@ -104,6 +104,9 @@ class CaseProperty(models.Model):
                 datetime.strptime(value, ISO_DATE_FORMAT)
             except ValueError:
                 raise exceptions.InvalidDate()
+        elif value and self.data_type == 'select':
+            if not self.allowed_values.filter(allowed_value=value).exists():
+                raise exceptions.InvalidSelectValue()
 
 
 class CasePropertyAllowedValue(models.Model):

--- a/corehq/apps/data_dictionary/tests/test_models.py
+++ b/corehq/apps/data_dictionary/tests/test_models.py
@@ -4,7 +4,7 @@ import uuid
 from django.test import TestCase
 
 from corehq.apps.case_importer import exceptions
-from corehq.apps.data_dictionary.models import CaseProperty, CaseType
+from corehq.apps.data_dictionary.models import CaseProperty, CasePropertyAllowedValue, CaseType
 from corehq.apps.domain.shortcuts import create_domain
 
 
@@ -20,6 +20,11 @@ class TestCaseProperty(TestCase):
         cls.date_property = CaseProperty(case_type=cls.case_type, data_type="date", name="dob")
         cls.date_property.save()
         cls.valid_date = datetime.date.today().isoformat()
+        cls.select_property = CaseProperty.objects.create(
+            case_type=cls.case_type, data_type="select", name="status")
+        cls.valid_choices = ["todo", "in-progress", "complete"]
+        for choice in cls.valid_choices:
+            CasePropertyAllowedValue.objects.create(case_property=cls.select_property, allowed_value=choice)
 
     @classmethod
     def tearDownClass(cls):
@@ -42,3 +47,14 @@ class TestCaseProperty(TestCase):
         with self.assertRaises(exceptions.InvalidDate):
             # caller is responsible for stripping any surrounding whitespace
             self.date_property.check_validity(f"  {self.valid_date} ")
+
+    def test_check_valid_selections(self):
+        # Simply not raising an exception indicates it passes validity check
+        for choice in self.valid_choices:
+            self.select_property.check_validity(choice)
+
+    def test_check_invalid_choice(self):
+        # We require strict matching, including case. Uppercase a valid choice
+        # and ensure it is not accepted.
+        with self.assertRaises(exceptions.InvalidSelectValue):
+            self.select_property.check_validity(self.valid_choices[0].upper())

--- a/corehq/apps/data_dictionary/tests/utils.py
+++ b/corehq/apps/data_dictionary/tests/utils.py
@@ -1,10 +1,14 @@
-from corehq.apps.data_dictionary.models import CaseType, CaseProperty
+from corehq.apps.data_dictionary.models import CaseType, CaseProperty, CasePropertyAllowedValue
 
 
-def setup_data_dictionary(domain, case_type_name, prop_list=None):
+def setup_data_dictionary(domain, case_type_name, prop_list=None, allowed_values=None):
     prop_list = prop_list or []
+    allowed_values = allowed_values or {}
     CaseType.get_or_create(domain, case_type_name)
     for prop_name, data_type in prop_list:
         prop = CaseProperty.get_or_create(prop_name, case_type_name, domain)
         prop.data_type = data_type
         prop.save()
+        if prop_name in allowed_values:
+            for value in allowed_values[prop_name]:
+                CasePropertyAllowedValue.objects.create(case_property=prop, allowed_value=value)


### PR DESCRIPTION
Extend the existing validity checking (had been added just for dates) to also include validing that select values match values provided for the property in the data dictionary. As with dates, do this if and only if the feature flag for data dictionary import validation is enabled.

## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [ ] Risk label is set correctly
- [ ] All migrations are backwards compatible and won't block deploy
- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
- [ ] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations 
